### PR TITLE
[Fix] broken link and add others guides

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,50 @@
+> ### delete this section
+
+> Before you submit an issue, consider the following guidelines:
+
+> - Please search for related issues. Make sure you are not going to open a duplicate issue.
+> - Please specify what kind of issue it is and explain it in the title or content, e.g. `feature`, `bug`, `documentation`, `discussion`, `help wanted`... The issue will be tagged automatically by the robot of the project(Menbotics)
+
+## Type of Issue
+
+_What types of issue have you found with hypertrons-crx?_
+_Put an `x` in the boxes that apply_
+
+- [ ] Bug
+- [ ] Feature Request
+- [ ] Performance issue
+- [ ] Help Wanted
+- [ ] Documention incomplete
+- [ ] Test Improvement
+- [ ] Raise a Question
+
+## Introduction ot the issue
+
+[provide a general introduction to the issue you are logging and why it is relevant to this repository]
+
+## Process
+
+[complete the ordered list with the process to finding and recreating the issue, example below]
+
+1. User goes to delete a dataset (to save space or whatever)
+2. User gets popup modal warning
+3. User deletes and it's lost forever
+
+## Expected result
+
+[describe what you would expect to have resulted from this process]
+
+## Current result
+
+[describe what you you currently experiencing from this process, and thereby explain the bug]
+
+## Possible Fix
+
+[not obligatory, but suggest fixes or reasons for the bug]
+
+- Modal tells the user what dataset is being deleted, like “You are about to delete this dataset: car_crashes_2014.”
+- A temporary "Trashcan" where you can recover a just deleted dataset if you mess up (maybe it's only good for a few hours, and then it cleans the cache assuming you made the right decision).
+
+## screenshot
+
+[if relevant, include a screenshot]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Purpose
+
+_Describe the problem or feature in addition to a link to the issues._
+
+## Proposed changes
+
+_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._
+
+#### Open Questions and Pre-Merge TODOs
+
+- [ ] Use github checklists. When solved, check the box and explain the answer.
+
+#### Types of changes
+
+_What types of changes does your code introduce to hypertrons-crx?_
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+
+## Approach
+
+_How does this change address the problem?_
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/hypertrons/hypertrons-crx-website/blob/master/CONTRIBUTING.md) doc
+- [ ] I have signed the [CLA](https://cla-assistant.io/hypertrons/hypertrons-crx-website)
+- [ ] Lint and unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+
+## Further comments (Optional)
+
+_If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc..._
+_Links to blog posts, patterns, libraries or addons used to solve this problem_

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+
+- Trolling, insulting/derogatory comments, and personal or political attacks
+
+- Public or private harassment
+
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at syzhao1988@126.com. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).
+
+For answers to common questions about this code of conduct, see [FAQ](https://www.contributor-covenant.org/faq).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,181 @@
+# Contributing to `hypertrons-crx-website`
+
+It is warmly welcomed if you have the interest to contribute to `hypertrons-crx-website` and help make it even better than it is today! The following is a set of guidelines for contributing to `hypertrons-crx-website`.
+
+- [Code of Conduct](#coc)
+- [Submitting an Issue](#issue)
+- [Submitting a Pull Request](#pr)
+- [Coding Rules](#rules)
+
+## <a name="coc"></a> Code of Conduct
+
+We have adopted a [Code of Conduct][coc] to help us keep hypertrons-crx open and inclusive. Please read the full text so that you can understand what actions will and will not be tolerated.
+
+## <a name="issue"></a> Submitting an issue
+
+If you have any questions or feature requests, please feel free to [submit an issue][new-issue].
+
+Before you submit an issue, consider the following guidelines:
+
+- Please search for related issues. Make sure you are not going to open a duplicate issue.
+- Please specify what kind of issue it is and explain it in the title or content, e.g. `feature`, `bug`, `documentation`, `discussion`, `help wanted`... The issue will be tagged automatically by the robot of the project(Menbotics). See [supported issue labels][issue-label].
+
+To make the issue details as standard as possible, we set up an [Issue Template][issue-template] for issue reporters. Please be sure to follow the instructions to fill fields in the template.
+
+There are a lot of cases when you could open an issue:
+
+- bug report
+- feature-request
+- performance issues
+- feature design
+- help wanted
+- doc incomplete
+- test improvement
+- any questions on a project
+- and so on
+
+Also, we must remind you that when filling a new issue, please remember to remove the sensitive data from your post. Sensitive data could be passwords, secret keys, network locations, private business data, and so on.
+
+## <a name="pr"></a> Submitting a Pull Request
+
+To help you get your feet wet and get you familiar with our contribution process, we have collected some [good first issues][good-first-issues] that contain bugs or small features that have a relatively limited scope. This is a great place to get started.
+
+Before you submit your Pull Request (PR), consider the following guidelines.
+
+### 1. Claim an issue
+
+Be sure that an issue describes the problem you're fixing, or documents the design for the feature you'd like to add.
+
+If you decide to fix an issue, please be sure to check the comment thread in case somebody is already working on a fix. If nobody is working on it at the moment, please leave a comment with `/self-assign` stating that you intend to work on it so other people don't accidentally duplicate your effort. The robot of the project(Menbotics) will set assignees of the issue to yourself automatically.
+
+```shell
+/self-assign
+```
+
+If somebody claims an issue but doesn't follow up for more than two weeks, it's fine to take over it but you should still leave a comment.
+
+### 2. Fork and clone the repository
+
+Visit [hypertrons/hypertrons-crx][repo] repo and make your copy of the repository by **forking** it.
+
+And **clone** your copy of the repository to local, like :
+
+```shell
+# replace the XXX with your user name
+git clone git@github.com:XXX/hypertrons-crx-website.git
+cd hypertrons-crx-website
+```
+
+### 4. Create a new branch
+
+Create a new branch for development.
+
+```shell
+git checkout -b branch-name
+```
+
+The name of the branch should be semantic, avoiding words like 'update' or 'tmp'. We suggest using `feature/xxx`, if the modification is about to implement a new feature.
+
+### 5. Make your changes
+
+Now you can create your patch, including appropriate test cases in the new branch. Please read and follow our [Code Rules](#rules).
+
+### 6. Commit your changes
+
+Commit your changes If your changes pass the tests. You are encouraged to use [angular commit-message-format][angular-commit-message-format] to write commit message. In this way, we could have a more trackable history and an automatically generated changelog.
+
+```shell
+git add .
+git commit -sm "fix: add license headers (#264)"
+```
+
+### 7. Sync your local repository with the upstream
+
+Keep your local repository updated with the upstream repository by:
+
+```shell
+git remote add upstream git@github.com:hypertrons/hypertrons-crx-website.git
+git fetch upstream master
+git rebase upstream/master
+```
+
+If conflicts arise, you need to resolve the conflicts manually, then:
+
+```shell
+git add my-fix-file
+git rebase --continue
+```
+
+### 8. Push your branch to GitHub
+
+```shell
+git push -f origin branch-name
+```
+
+### 9. Create a Pull Request
+
+In GitHub, send a pull request to `hypertrons:hypertrons-crx`.
+
+Please sign our [Contributor License Agreement (CLA)](#cla) before sending PRs.
+
+To make sure we can easily recap what happened previously, we have prepared a [pull request template][pr-template] and you need to fill out the PR template. If you feel that some part of the template is redundant and your description is clear enough, you can just keep the necessary parts.
+
+The core team is monitoring for pull requests. We will review your pull request and either merge it, request changes to it, or close it with an explanation.
+
+If we suggest changes then:
+
+- Make the required updates.
+
+- Re-run the test to ensure tests are still passing.
+
+- Commit your changes with `--amend` and force push to your GitHub repository (this will update your Pull Request):
+
+  ```shell
+  git add .
+  git commit --amend
+  git push -f origin branch-name
+  ```
+
+That's it! Thank you for your contribution!
+
+### 10. After your pull request is merged
+
+After your pull request is merged, you can safely delete your branch and pull the changes from the upstream repository:
+
+- Delete the remote branch on GitHub either through the GitHub web UI or your local shell as follows:
+
+  ```shell
+  git push origin --delete branch-name
+  ```
+
+- Check out the master branch:
+
+  ```shell
+  git checkout master -f
+  ```
+
+- Delete the local branch:
+
+  ```shell
+  git branch -D my-fix-branch
+  ```
+
+- Update your master with the latest upstream version:
+
+  ```shell
+  git pull --ff upstream master
+  ```
+
+## <a name="cla"></a> Signing the CLA
+
+Please sign our [Contributor License Agreement (CLA)][cla] before sending pull requests. For any code changes to be accepted, the CLA must be signed.
+
+[coc]: ./CODE_OF_CONDUCT.md
+[new-issue]: https://github.com/hypertrons/hypertrons-crx-website/issues/new
+[issue-label]: https://github.com/hypertrons/hypertrons-crx-website/labels
+[good-first-issues]: https://github.com/hypertrons/hypertrons-crx-website/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+
+[repo]: https://github.com/hypertrons/hypertrons-crx-website
+[angular-commit-message-format]: https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
+[pr-template]: ./.github/pull_request_template.md
+[issue-template]: ./.github/issue_template.md
+[cla]: https://cla-assistant.io/hypertrons/hypertrons-crx-website

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ If somebody claims an issue but doesn't follow up for more than two weeks, it's 
 
 ### 2. Fork and clone the repository
 
-Visit [hypertrons/hypertrons-crx][repo] repo and make your copy of the repository by **forking** it.
+Visit [hypertrons/hypertrons-crx-website][repo] repo and make your copy of the repository by **forking** it.
 
 And **clone** your copy of the repository to local, like :
 
@@ -114,7 +114,7 @@ git push -f origin branch-name
 
 ### 9. Create a Pull Request
 
-In GitHub, send a pull request to `hypertrons:hypertrons-crx`.
+In GitHub, send a pull request to `hypertrons:hypertrons-crx-website`.
 
 Please sign our [Contributor License Agreement (CLA)](#cla) before sending PRs.
 


### PR DESCRIPTION
Hi there,

I have a fix out the broken links of CONTRIBUTING.md and added the contents for it.  Few changes
- created and updated the guideline of hypertrons-crx-website (CONTRIBUTING.md)
- created GitHub issue and PR templates which are referenced to CONTRIBUTING.md
- created a code of conduct too and updated the [license agreement](https://cla-assistant.io/hypertrons/hypertrons-crx-website) for making contributions.

> Also maintainer should setup issue label bot.
